### PR TITLE
Support Alpine Linux

### DIFF
--- a/lib/DB/Pg/Native.pm6
+++ b/lib/DB/Pg/Native.pm6
@@ -1,6 +1,6 @@
 use NativeCall;
 
-my constant LIBPQ = 'pq';  # libpq.so
+my constant LIBPQ = 'pq', v5;  # libpq.so
 
 enum ConnStatusType <
     CONNECTION_OK


### PR DESCRIPTION
Alpine Linux only installs `libpq.so.5` and `libpq.so.5.12`, no unversioned `libpq.so`. As such this library fails there with:

```
Cannot locate native library 'libpq.so': Error loading shared library libpq.so: No such file or directory
```
https://pkgs.alpinelinux.org/contents?branch=v3.12&name=libpq&arch=x86_64&repo=main

This change adds a major version number to the native attribute in order to solve this.

While this is the current stable major version number in many distros I am unsure how to handle future changes. DBIish actually resorts to runtime checking with:

```
use NativeLibs;

constant LIB = NativeLibs::Searcher.at-runtime('pq', 'PQstatus', 5);
```
https://github.com/raku-community-modules/DBIish/blob/master/lib/DBDish/Pg/Native.pm6

But even then they seem to specify major version 5 so I think we're in good company with this change.