### PR TITLE
Invert escape order for array values

### DIFF
--- a/lib/DB/Pg/Converter.rakumod
+++ b/lib/DB/Pg/Converter.rakumod
@@ -243,8 +243,8 @@ multi method convert(@value, Array:U $type)
                 default
                 {
                     '"' ~
-                        .subst(/\"/, '\\"', :g)
                         .subst(/\\/, Q<\\>, :g)
+                        .subst(/\"/, '\\"', :g)
                     ~ '"'
                 }
             }).join(',')

--- a/t/10-type-converter.t
+++ b/t/10-type-converter.t
@@ -8,6 +8,9 @@ ok my $c = DB::Pg::Converter.new, 'new converter';
 is $c.convert('bool', 't'), True, 'bool t';
 is $c.convert('bool', 'f'), False, 'bool f';
 
+is $c.convert([ 'th"is' ], Array[Str]),
+    Q<{"th\"is"}>, 'array with quote';
+
 is $c.convert([ Q<th\is> ], Array[Str]),
     Q<{"th\\is"}>, 'array with embedded backslash';
 


### PR DESCRIPTION
So that we can have quotes in array values

Otherwise, `a"b` became `a\"b` became `a\\"b`, and the `"` wasn't escaped anymore.